### PR TITLE
Define Java version with toolchain

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,12 @@ plugins {
 
 spine.enableJava().server()
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+// Define the Java Language version to build the project
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
 
 // Add JUnit to the project.
 apply from: "$rootDir/gradle/tests.gradle"


### PR DESCRIPTION
This PR replace `sourceCompatibility` with Java toolchain added to Gradle starting version 6.7.

Visit Gradle [blog](https://blog.gradle.org/java-toolchains) and [userguide](https://docs.gradle.org/current/userguide/toolchains.html) for more information.

![Screenshot 2021-02-17 at 11 20 16](https://user-images.githubusercontent.com/50623030/108187934-aae12380-7117-11eb-8ee1-4ee51199dc9a.png)
